### PR TITLE
Update config.yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
          name: Build
          command: |
            go version
-           go build -o terraform-provider-citrixadc ../main.go
+           CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o terraform-provider-citrixadc ../main.go
 
      - run:
          name: Install Terraform


### PR DESCRIPTION
Add support for alpine-based images to allow terraform-provider-citrixadc to be used in an alpine docker image like the one shipped by [Hashicorp for Terraform](https://hub.docker.com/r/hashicorp/terraform/) 

Should resolve #116